### PR TITLE
Pinning Actions via SHA

### DIFF
--- a/.github/workflows/codeQL-review.yml
+++ b/.github/workflows/codeQL-review.yml
@@ -10,6 +10,6 @@ on: [pull_request]
 
 jobs:
   codeql:
-    uses: ministryofjustice/data-platform-github-actions/.github/workflows/codeql-analysis.yml@main
+    uses: ministryofjustice/data-platform-github-actions/.github/workflows/codeql-analysis.yml@078037621080098635691c669d30330087880fa8 #v3.5.1
     with:
       languages: '["python", "actions"]'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,4 +16,4 @@ jobs:
     if: github.event.repository.private == false
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-dependency-review.yml@9fbe4cbba23d4a768eb36462458a4cfcb63682e1 # v5.2.0
+    uses: ministryofjustice/analytical-platform-airflow-github-actions/.github/workflows/shared-dependency-review.yml@9fbe4cbba23d4a768eb36462458a4cfcb63682e1 #v5.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use specific commit hashes for their reusable actions, improving build reproducibility and security. The most important changes are:

**Workflow Dependency Pinning:**

* [`.github/workflows/codeQL-review.yml`](diffhunk://#diff-6b7a7ae69c4187342bb18036f2f325ebe56abd70f16cbf0dedce9f979ced69bbL13-R13): The `codeql-analysis.yml` workflow is now referenced by a specific commit hash (`078037621080098635691c669d30330087880fa8`) instead of the floating `main` branch, ensuring consistent and predictable runs.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L14-R14): The `setup-python` action is now pinned to commit `a309ff8b426b58ec0e2a45f0f869d46889d02405` (corresponding to v6.2.0) instead of just the version tag, further improving workflow security and reliability.